### PR TITLE
fix: maintain first path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,9 @@ const getRelativePathName = (path: string) => {
   if (p[0] === '.')
     p.shift()
 
-  // remove the given path like `image`
-  if (p.length >= 2)
-    p.shift()
+  // // remove the given path like `image`
+  // if (p.length >= 2)
+  //   p.shift()
 
   // remove extension
   const f = p[p.length - 1].split('.')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { batSharp } from '../src/index'
 
-const inputArr = ['./images/**/*.png']
+const inputArr = ['./**/*.png']
 const outputPath = './images_compressed'
 
 await batSharp({


### PR DESCRIPTION
In last PR, if I set the input array to `./images/**/*.png`, the pictures in the `image/` path will be put into the array. After they are processed, and then write to `output/`. But sometimes All the pictures in root path (`./**/*.png`) should be conpressed, and they will be write to the wrong path. This PR is to fix this problem.